### PR TITLE
Add utility to fetch Vault secrets for Bamboo plans

### DIFF
--- a/vaultfetcher/README.md
+++ b/vaultfetcher/README.md
@@ -1,0 +1,66 @@
+# Vault Secret Fetcher
+
+This utility reads a `vault_secrets.yaml` file, validates the schema, and fetches secrets from HashiCorp Vault using the official Go SDK. The resulting passwords are written to `vault/vault_received.yaml` in the format `name=password` under the `vault` key.
+
+## Configuration
+
+The configuration file must contain a `vault_secrets` array. Each entry describes the Vault location to read:
+
+```yaml
+vault_secrets:
+  - name: artifactoryPassword
+    default:
+      vault:
+        account_id: GA00016094
+        namespace: APS00376-non
+  - name: iiq_console_password
+    default:
+      vault:
+        account_id: GA03000912
+        namespace: AP668493612630IG-NON
+    branch-overrides:
+      - name: iiq-develop
+        vault:
+          account_id: GA00300812
+          namespace: AP6649361230IG-NON
+```
+
+* `name` – identifier for the secret in the output file.
+* `default.vault.account_id` – CyberArk account ID (used to build the Vault path `cyberark/accounts/<account_id>`).
+* `default.vault.namespace` – Vault namespace for the default lookup.
+* `branch-overrides` – optional overrides keyed by branch name. If the supplied branch (from the `--branch` flag or detected Bamboo environment variables) matches one of these entries, its `vault` block is used instead of the default.
+
+The loader validates that each secret has a unique `name` and that every target includes both an `account_id` and `namespace`.
+
+## Usage
+
+Set the required Vault environment variables and execute the binary:
+
+```bash
+export VAULT_ADDR=https://vault.example.com
+export VAULT_TOKEN=...
+
+cd vaultfetcher
+GOFLAGS=-mod=mod go run ./cmd/vaultfetcher \
+  --config path/to/vault_secrets.yaml \
+  --branch "$BAMBOO_PLAN_REPOSITORY_BRANCH" \
+  --output vault/vault_received.yaml
+```
+
+Flags:
+
+* `--config` – path to the YAML file (default `vault_secrets.yaml`).
+* `--branch` – branch name for override resolution. If omitted, the program inspects Bamboo variables such as `BAMBOO_PLAN_REPOSITORY_BRANCH`.
+* `--output` – destination for the rendered YAML (default `vault/vault_received.yaml`).
+* `--mount` – KV v2 mount path (default `secrets/sync`).
+* `--password-field` – key in the Vault secret that contains the password (default `password`).
+* `--vault-addr` – override for the Vault address (falls back to `VAULT_ADDR`).
+* `--timeout` – request timeout per secret (default 30s).
+
+The output file contains a `vault` array with `name=password` strings that Bamboo can consume.
+
+## Notes
+
+* The program uses the official Vault Go SDK (`github.com/hashicorp/vault/api`) and expects KV v2 semantics at the provided mount path.
+* Namespace support is handled by creating a client per secret and calling `SetNamespace` before each request.
+* When running in environments without network access, `go mod tidy` may fail to download module dependencies. In such cases, run the command on a machine with access to populate `go.sum` before compiling.

--- a/vaultfetcher/cmd/vaultfetcher/main.go
+++ b/vaultfetcher/cmd/vaultfetcher/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"gopkg.in/yaml.v3"
+
+	"github.com/example/vaultfetcher/internal/config"
+)
+
+func main() {
+	var (
+		configPath    = flag.String("config", "vault_secrets.yaml", "Path to the vault secrets definition file")
+		branchName    = flag.String("branch", "", "Branch name used to resolve branch-overrides")
+		outputPath    = flag.String("output", filepath.Join("vault", "vault_received.yaml"), "Destination file for the received secrets")
+		mountPath     = flag.String("mount", "secrets/sync", "Vault KV v2 mount path")
+		passwordField = flag.String("password-field", "password", "Field within the Vault secret to read")
+		vaultAddr     = flag.String("vault-addr", "", "Override Vault address (defaults to VAULT_ADDR env var)")
+		timeout       = flag.Duration("timeout", 30*time.Second, "Maximum duration for a single Vault request")
+	)
+
+	flag.Parse()
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	branch := resolveBranchName(*branchName)
+
+	addr := strings.TrimSpace(*vaultAddr)
+	if addr == "" {
+		addr = strings.TrimSpace(os.Getenv("VAULT_ADDR"))
+	}
+	if addr == "" {
+		log.Fatal("VAULT_ADDR environment variable or --vault-addr flag must be provided")
+	}
+
+	token := strings.TrimSpace(os.Getenv("VAULT_TOKEN"))
+	if token == "" {
+		log.Fatal("VAULT_TOKEN environment variable must be provided")
+	}
+
+	mount := strings.Trim(strings.TrimSpace(*mountPath), "/")
+	if mount == "" {
+		log.Fatal("mount path cannot be empty")
+	}
+
+	log.Printf("resolved branch: %q", branch)
+
+	results := make([]string, 0, len(cfg.VaultSecrets))
+
+	for _, secret := range cfg.VaultSecrets {
+		target := secret.TargetForBranch(branch)
+		password, err := fetchPassword(context.Background(), addr, token, mount, target, *passwordField, *timeout)
+		if err != nil {
+			log.Fatalf("fetch secret %q: %v", secret.Name, err)
+		}
+		results = append(results, fmt.Sprintf("%s=%s", secret.Name, password))
+		log.Printf("retrieved secret %q from namespace %q", secret.Name, target.Namespace)
+	}
+
+	if err := writeOutput(*outputPath, results); err != nil {
+		log.Fatalf("write output: %v", err)
+	}
+
+	log.Printf("wrote %d secrets to %s", len(results), *outputPath)
+}
+
+func resolveBranchName(flagValue string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		return flagValue
+	}
+
+	envVars := []string{
+		"BAMBOO_PLAN_REPOSITORY_BRANCH",
+		"BAMBOO_REPO_BRANCH",
+		"BAMBOO_BRANCH_NAME",
+		"GIT_BRANCH",
+		"BRANCH_NAME",
+	}
+
+	for _, env := range envVars {
+		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+			return v
+		}
+	}
+
+	return ""
+}
+
+func fetchPassword(ctx context.Context, addr, token, mount string, target config.Target, passwordField string, timeout time.Duration) (string, error) {
+	conf := api.DefaultConfig()
+	conf.Address = addr
+
+	client, err := api.NewClient(conf)
+	if err != nil {
+		return "", fmt.Errorf("new client: %w", err)
+	}
+
+	client.SetToken(token)
+	if strings.TrimSpace(target.Namespace) != "" {
+		client.SetNamespace(target.Namespace)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	path := fmt.Sprintf("cyberark/accounts/%s", target.AccountID)
+	secret, err := client.KVv2(mount).Get(ctx, path)
+	if err != nil {
+		return "", fmt.Errorf("read secret at %s (namespace %s): %w", path, target.Namespace, err)
+	}
+
+	value, ok := secret.Data[passwordField]
+	if !ok {
+		return "", fmt.Errorf("field %q missing in secret %s", passwordField, path)
+	}
+
+	password, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("field %q in secret %s is not a string", passwordField, path)
+	}
+
+	if password == "" {
+		return "", errors.New("password value is empty")
+	}
+
+	return password, nil
+}
+
+func writeOutput(path string, results []string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	type output struct {
+		Vault []string `yaml:"vault"`
+	}
+
+	out := output{Vault: results}
+
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("marshal output: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	return nil
+}

--- a/vaultfetcher/go.mod
+++ b/vaultfetcher/go.mod
@@ -1,0 +1,8 @@
+module github.com/example/vaultfetcher
+
+go 1.24.3
+
+require (
+    github.com/hashicorp/vault/api v1.14.0
+    gopkg.in/yaml.v3 v3.0.1
+)

--- a/vaultfetcher/internal/config/config.go
+++ b/vaultfetcher/internal/config/config.go
@@ -1,0 +1,206 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// File represents the root of the vault_secrets.yaml configuration file.
+type File struct {
+	VaultSecrets []Secret `yaml:"vault_secrets"`
+}
+
+// Secret describes a single secret lookup definition.
+type Secret struct {
+	Name            string           `yaml:"name"`
+	Default         TargetWrapper    `yaml:"default"`
+	BranchOverrides []BranchOverride `yaml:"branch-overrides"`
+}
+
+// TargetWrapper provides parity with the YAML layout where a target is nested
+// under a "vault" key.
+type TargetWrapper struct {
+	Vault Target `yaml:"vault"`
+}
+
+// BranchOverride allows overriding the default target for a specific branch.
+type BranchOverride struct {
+	Name  string `yaml:"name"`
+	Vault Target `yaml:"vault"`
+}
+
+// Target contains the fields required to locate the secret in Vault.
+type Target struct {
+	AccountID      string `yaml:"account_id"`
+	Namespace      string `yaml:"namespace"`
+	NamespaceAlias string `yaml:"namepsace"`
+}
+
+// Normalize normalises data read from YAML into canonical form.
+func (t *Target) Normalize() {
+	if t.Namespace == "" {
+		t.Namespace = t.NamespaceAlias
+	}
+}
+
+// Load reads and validates a configuration file from disk.
+func Load(path string) (*File, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var cfg File
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	cfg.Normalize()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// Normalize walks the configuration applying normalisation rules.
+func (f *File) Normalize() {
+	for i := range f.VaultSecrets {
+		f.VaultSecrets[i].Normalize()
+	}
+}
+
+// Normalize applies normalisation to the secret and its nested targets.
+func (s *Secret) Normalize() {
+	s.Default.Vault.Normalize()
+	for i := range s.BranchOverrides {
+		s.BranchOverrides[i].Vault.Normalize()
+	}
+}
+
+// Validate ensures the configuration adheres to the expected schema and
+// business rules.
+func (f *File) Validate() error {
+	if len(f.VaultSecrets) == 0 {
+		return &ValidationError{Issues: []string{"no vault_secrets entries defined"}}
+	}
+
+	var issues []string
+	seenNames := make(map[string]int)
+	for i := range f.VaultSecrets {
+		s := &f.VaultSecrets[i]
+		if strings.TrimSpace(s.Name) == "" {
+			issues = append(issues, fmt.Sprintf("secret at index %d is missing a name", i))
+		} else {
+			seenNames[s.Name]++
+			if seenNames[s.Name] > 1 {
+				issues = append(issues, fmt.Sprintf("duplicate secret name %q", s.Name))
+			}
+		}
+
+		if err := validateTarget(s.Default.Vault, fmt.Sprintf("secret %q default", s.Name)); err != nil {
+			issues = append(issues, err.Error())
+		}
+
+		overrideNames := make(map[string]struct{})
+		for j := range s.BranchOverrides {
+			o := &s.BranchOverrides[j]
+			if strings.TrimSpace(o.Name) == "" {
+				issues = append(issues, fmt.Sprintf("secret %q override at index %d missing name", s.Name, j))
+			} else {
+				if _, ok := overrideNames[o.Name]; ok {
+					issues = append(issues, fmt.Sprintf("secret %q has duplicate override for branch %q", s.Name, o.Name))
+				}
+				overrideNames[o.Name] = struct{}{}
+			}
+			if err := validateTarget(o.Vault, fmt.Sprintf("secret %q override %q", s.Name, o.Name)); err != nil {
+				issues = append(issues, err.Error())
+			}
+		}
+	}
+
+	if len(issues) > 0 {
+		return &ValidationError{Issues: issues}
+	}
+
+	return nil
+}
+
+func validateTarget(t Target, context string) error {
+	if strings.TrimSpace(t.AccountID) == "" && strings.TrimSpace(t.Namespace) == "" {
+		return fmt.Errorf("%s: missing account_id and namespace", context)
+	}
+
+	var issues []string
+	if strings.TrimSpace(t.AccountID) == "" {
+		issues = append(issues, "account_id is required")
+	}
+	if strings.TrimSpace(t.Namespace) == "" {
+		issues = append(issues, "namespace is required")
+	}
+
+	if len(issues) > 0 {
+		return fmt.Errorf("%s: %s", context, strings.Join(issues, ", "))
+	}
+
+	return nil
+}
+
+// ValidationError groups schema validation issues.
+type ValidationError struct {
+	Issues []string
+}
+
+// Error implements the error interface.
+func (v *ValidationError) Error() string {
+	return fmt.Sprintf("configuration validation failed: %s", strings.Join(v.Issues, "; "))
+}
+
+// Is allows errors.Is checks against ValidationError.
+func (v *ValidationError) Is(target error) bool {
+	_, ok := target.(*ValidationError)
+	return ok
+}
+
+// TargetForBranch resolves the Vault target for the given branch name.
+func (s *Secret) TargetForBranch(branch string) Target {
+	candidates := branchCandidates(branch)
+	for _, candidate := range candidates {
+		for _, override := range s.BranchOverrides {
+			if override.Name == candidate {
+				return override.Vault
+			}
+		}
+	}
+	return s.Default.Vault
+}
+
+func branchCandidates(branch string) []string {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return nil
+	}
+
+	candidates := []string{branch}
+
+	if strings.HasPrefix(branch, "refs/heads/") {
+		candidates = append(candidates, strings.TrimPrefix(branch, "refs/heads/"))
+	}
+	if strings.HasPrefix(branch, "origin/") {
+		candidates = append(candidates, strings.TrimPrefix(branch, "origin/"))
+	}
+
+	return candidates
+}
+
+// MustDefaultBranchTarget fetches the default target, ensuring it is valid.
+func (s *Secret) MustDefaultBranchTarget() (Target, error) {
+	if s.Default.Vault.AccountID == "" || s.Default.Vault.Namespace == "" {
+		return Target{}, errors.New("default vault target is incomplete")
+	}
+	return s.Default.Vault, nil
+}

--- a/vaultfetcher/vault_secrets.example.yaml
+++ b/vaultfetcher/vault_secrets.example.yaml
@@ -1,0 +1,16 @@
+vault_secrets:
+  - name: artifactoryPassword
+    default:
+      vault:
+        account_id: GA00016094
+        namespace: APS00376-non
+  - name: iiq_console_password
+    default:
+      vault:
+        account_id: GA03000912
+        namespace: AP668493612630IG-NON
+    branch-overrides:
+      - name: iiq-develop
+        vault:
+          account_id: GA00300812
+          namespace: AP6649361230IG-NON


### PR DESCRIPTION
## Summary
- add a standalone vaultfetcher module that validates vault_secrets.yaml definitions and resolves branch overrides
- implement a CLI that uses the Vault Go SDK to read CyberArk account passwords and emit name=password pairs
- document configuration, usage, and provide an example secrets file for Bamboo plans

## Testing
- not run (module dependencies require external network access to download)


------
https://chatgpt.com/codex/tasks/task_e_68d7e576d2c08332bf5d4756cca99bc4